### PR TITLE
feat: CliqueAI v0.0.4

### DIFF
--- a/CliqueAI/validator.py
+++ b/CliqueAI/validator.py
@@ -64,7 +64,7 @@ class Validator(BaseValidatorNeuron):
                 try:
                     coldkey_to_stake_on_owner[coldkey] = self.subtensor.get_stake(
                         coldkey, self.get_owner_hotkey(), netuid=self.config.netuid
-                    ).rao
+                    ).tao
                 except Exception as e:
                     coldkey_to_stake_on_owner[coldkey] = 0
                     continue

--- a/CliqueAI/validator.py
+++ b/CliqueAI/validator.py
@@ -63,7 +63,7 @@ class Validator(BaseValidatorNeuron):
             for coldkey in set(coldkeys):
                 try:
                     coldkey_to_stake_on_owner[coldkey] = self.subtensor.get_stake(
-                        coldkey, self.owner_hotkey, netuid=self.config.netuid
+                        coldkey, self.get_owner_hotkey(), netuid=self.config.netuid
                     ).rao
                 except Exception as e:
                     coldkey_to_stake_on_owner[coldkey] = 0

--- a/common/base/__init__.py
+++ b/common/base/__init__.py
@@ -1,5 +1,5 @@
-base_version = "0.0.3"
-validator_version = "0.0.3"
+base_version = "0.0.4"
+validator_version = "0.0.4"
 
 
 def _version_to_int(version_str: str) -> int:

--- a/min_compute.yml
+++ b/min_compute.yml
@@ -7,7 +7,7 @@
 
 # NOTE: Specification for miners may be different from validators
 
-version: '0.0.3' # update this version key as needed, ideally should match your release version
+version: '0.0.4' # update this version key as needed, ideally should match your release version
 
 compute_spec:
 


### PR DESCRIPTION
# Fixes:

- Replaced direct `owner_hotkey` reference with `get_owner_hotkey()`.
- Switched stake unit from `.rao` to `.tao` to use the correct number of digits.

