### PR TITLE
CliqueAI v0.0.12

### DIFF
--- a/CliqueAI/selection/problem_selector.py
+++ b/CliqueAI/selection/problem_selector.py
@@ -21,12 +21,6 @@ class Problem(BaseModel):
 PROBLEMS = [
     Problem(
         label="general",
-        vertex_range=Range(min=690, max=700),
-        edge_range=Range(min=0, max=max_int),
-        difficulty=0.1,
-    ),
-    Problem(
-        label="general",
         vertex_range=Range(min=290, max=300),
         edge_range=Range(min=100, max=max_int),
         difficulty=0.2,
@@ -37,9 +31,15 @@ PROBLEMS = [
         edge_range=Range(min=0, max=max_int),
         difficulty=0.4,
     ),
+    Problem(
+        label="general",
+        vertex_range=Range(min=690, max=700),
+        edge_range=Range(min=0, max=max_int),
+        difficulty=1,
+    ),
 ]
 
-TIME_LIMITS = [7.5, 10, 15, 30]
+TIME_LIMITS = [6, 7.5, 10, 15, 30]
 
 
 class ProblemSelector:

--- a/common/base/__init__.py
+++ b/common/base/__init__.py
@@ -1,5 +1,5 @@
-base_version = "0.0.11"
-validator_version = "0.0.11"
+base_version = "0.0.12"
+validator_version = "0.0.12"
 
 
 def _version_to_int(version_str: str) -> int:

--- a/min_compute.yml
+++ b/min_compute.yml
@@ -7,7 +7,7 @@
 
 # NOTE: Specification for miners may be different from validators
 
-version: '0.0.11' # update this version key as needed, ideally should match your release version
+version: '0.0.12' # update this version key as needed, ideally should match your release version
 
 compute_spec:
 


### PR DESCRIPTION
# Improvements
- Increased 700-vertex graph difficulty from `0.1` to `1`.
- Added `6s` option to `TIME_LIMITS`.