### PR TITLE
CliqueAI v0.0.13

### DIFF
--- a/common/base/__init__.py
+++ b/common/base/__init__.py
@@ -1,5 +1,5 @@
-base_version = "0.0.12"
-validator_version = "0.0.12"
+base_version = "0.0.13"
+validator_version = "0.0.13"
 
 
 def _version_to_int(version_str: str) -> int:

--- a/common/base/validator.py
+++ b/common/base/validator.py
@@ -255,8 +255,7 @@ class BaseValidatorNeuron(BaseNeuron):
         """
         Sets the validator weights to the metagraph hotkeys based on the scores it has received from the miners. The weights determine the trust and incentive level the validator assigns to miner nodes on the network.
         """
-        LAMBDA_WEIGHTS = 0.065
-        # LAMBDA_WEIGHTS = 0.1
+        LAMBDA_WEIGHTS = 0.5
 
         # Check if self.scores contains any NaN values and log a warning if it does.
         if np.isnan(self.scores).any():

--- a/common/base/validator.py
+++ b/common/base/validator.py
@@ -243,6 +243,14 @@ class BaseValidatorNeuron(BaseNeuron):
             self.wandb_client.finish()
             bt.logging.info("WandB client stopped.")
 
+    def _sigmoid_weight(self, normalized_incentives: np.ndarray, midpoint: float, steepness: float) -> np.ndarray:
+        """
+        Apply sigmoid scaling to normalized incentives.
+        """
+        x = (normalized_incentives - midpoint) / steepness
+        sigmoid_incentives = 1 / (1 + np.exp(-x))
+        return sigmoid_incentives
+
     def set_weights(self):
         """
         Sets the validator weights to the metagraph hotkeys based on the scores it has received from the miners. The weights determine the trust and incentive level the validator assigns to miner nodes on the network.
@@ -268,8 +276,20 @@ class BaseValidatorNeuron(BaseNeuron):
         else:
             normalized = (self.scores - min_val) / range_val
 
-        weights = LAMBDA_WEIGHTS * normalized
-        weights[0] = (1.0 - LAMBDA_WEIGHTS) * sum(normalized)
+        # Apply sigmoid scaling to the normalized scores to determine the weights.
+        zero_mask = (normalized == 0)
+        nonzero_normalized = normalized[~zero_mask]
+        if nonzero_normalized.size > 0:
+            midpoint = np.median(nonzero_normalized)
+            steepness = max(np.percentile(nonzero_normalized, 75) - np.percentile(nonzero_normalized, 25), 0.1)  # IQR
+            sigmoid_weights = self._sigmoid_weight(normalized, midpoint=midpoint, steepness=steepness)
+            sigmoid_weights[zero_mask] = 0.0
+        else:
+            sigmoid_weights = normalized
+
+        # Combine the sigmoid weights with a lambda to determine the final weights.
+        weights = LAMBDA_WEIGHTS * sigmoid_weights
+        weights[0] = (1.0 - LAMBDA_WEIGHTS) * sum(sigmoid_weights)
         uids = np.asarray(self.metagraph.uids, dtype=np.int64)
         bt.logging.debug("weights", weights)
         bt.logging.debug("uids", uids)

--- a/min_compute.yml
+++ b/min_compute.yml
@@ -7,7 +7,7 @@
 
 # NOTE: Specification for miners may be different from validators
 
-version: '0.0.12' # update this version key as needed, ideally should match your release version
+version: '0.0.13' # update this version key as needed, ideally should match your release version
 
 compute_spec:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ networkx==3.4.2
 pytest
 substrate-interface
 bittensor==9.10.0
-bittensor-cli
+bittensor-cli==9.17.0
 httpx
 scipy==1.15.3
 PyYAML==6.0.2


### PR DESCRIPTION
# Improvements

- Replaced linear scaling with a Sigmoid function using median and IQR (Interquartile Range). This better differentiates top-tier miners while naturally filtering out noise and low-performers.
- Updated `LAMBDA_WEIGHTS` to `0.5`.

# Dependencies

- Pinned bittensor-cli version to `9.17.0`.