### PR TITLE
CliqueAI v0.0.15

### DIFF
--- a/CliqueAI/graph/__init__.py
+++ b/CliqueAI/graph/__init__.py
@@ -1,0 +1,7 @@
+"""
+Codec utilities for CliqueAI
+"""
+
+from .codec import GraphCodec
+
+__all__ = ["GraphCodec"]

--- a/CliqueAI/graph/codec.py
+++ b/CliqueAI/graph/codec.py
@@ -11,7 +11,8 @@ class GraphCodec:
     """
     Provides graph encoding and decoding functionalities.
     1. adjacency_list <-> adjacency_matrix
-    2. adjacency_matrix <-> base92 encoded string (bitwise)
+    2. edge_list <-> adjacency_matrix
+    3. adjacency_matrix <-> base92 encoded string (bitwise)
     """
 
     def __init__(
@@ -47,6 +48,26 @@ class GraphCodec:
             neighbors = [j for j, v in enumerate(row) if v == 1]
             adj_list.append(neighbors)
         return adj_list
+    
+    @staticmethod
+    def edge_list_to_matrix(edge_list: list[list[int]], n: int) -> list[list[int]]:
+        """Convert edge list to adjacency matrix"""
+        adj_matrix = [[0] * n for _ in range(n)]
+        for u, v in edge_list:
+            adj_matrix[u][v] = 1
+            adj_matrix[v][u] = 1
+        return adj_matrix
+
+    @staticmethod
+    def matrix_to_edge_list(adj_matrix: list[list[int]]) -> list[list[int]]:
+        """Convert adjacency matrix to edge list"""
+        edge_list = []
+        n = len(adj_matrix)
+        for i in range(n):
+            for j in range(i + 1, n):
+                if adj_matrix[i][j] == 1:
+                    edge_list.append([i, j])
+        return edge_list
 
     # Base92 helpers
     def _min_digits_for_bits(self, r_bits: int) -> int:

--- a/CliqueAI/miner.py
+++ b/CliqueAI/miner.py
@@ -2,7 +2,7 @@ import time
 import typing
 
 import bittensor as bt
-from CliqueAI.clique_algorithms import networkx_algorithm, scattering_clique_algorithm
+from CliqueAI.clique_algorithms import networkx_algorithm
 from CliqueAI.graph.codec import GraphCodec
 from CliqueAI.protocol import MaximumCliqueOfLambdaGraph
 from common.base.miner import BaseMinerNeuron
@@ -33,6 +33,7 @@ class Miner(BaseMinerNeuron):
         adjacency_list = codec.matrix_to_list(adjacency_matrix)
         maximum_clique: list[int] = networkx_algorithm(synapse.number_of_nodes, adjacency_list)
         # or use GNN models
+        # from CliqueAI.clique_algorithms import scattering_clique_algorithm
         # maximum_clique = scattering_clique_algorithm(synapse.number_of_nodes, adjacency_list)
         bt.logging.info(
             f"Maximum clique found: {maximum_clique} with size {len(maximum_clique)}"

--- a/CliqueAI/selection/miner_selector.py
+++ b/CliqueAI/selection/miner_selector.py
@@ -10,8 +10,8 @@ class MinerSelector:
     ):
         self.current_block = current_block
         self.snapshot = snapshot
-        self.miner_weights_cache = {}  # difficulty -> weights mapping
         self.miner_uids = self._filter_validators()
+        self.reference_r = 1.5
 
     def _filter_validators(self) -> list[int]:
         """
@@ -31,37 +31,27 @@ class MinerSelector:
             uids.append(uid)
         return uids
 
-    def miner_weights(self, difficulty: float) -> np.ndarray:
+    def miner_selection_probabilities(self, difficulty: float) -> np.ndarray:
         """
-        Calculate the weights of miners based on their stake and the difficulty.
+        Calculate equal sampling probabilities for all miners.
 
         Args:
             difficulty (float): The difficulty threshold for sampling miners.
 
         Returns:
-            np.ndarray: An array of weights for each miner.
+            np.ndarray: An array of selection probabilities for each miner.
         """
-        if difficulty in self.miner_weights_cache:
-            return self.miner_weights_cache[difficulty]
+        if not self.miner_uids:
+            return np.array([])
 
-        s_m = [
-            self.snapshot.alpha_stakes[uid]
-            for uid in self.miner_uids
-        ]
-        S = sum(s_m) / len(self.miner_uids)
-        if S == 0:
-            x_m = np.array([1] * len(self.miner_uids))
-        else:
-            x_m = np.sqrt(1 + s_m / S)
-
+        x_m = np.sqrt(1 + self.reference_r)
         delta = x_m - difficulty - 0.5
         P = 1 - np.exp(-np.maximum(0, delta))
-        self.miner_weights_cache[difficulty] = P
-        return P
+        return np.full(len(self.miner_uids), P)
 
     def sample_miner_uids(self, difficulty: float) -> list[int]:
         """
-        Sample miners based on their stake weights and a given difficulty.
+        Sample miners using equal selection probabilities.
 
         Args:
             difficulty (float): The difficulty threshold for sampling miners.
@@ -69,7 +59,7 @@ class MinerSelector:
         Returns:
             list[int]: A list of selected miner UIDs.
         """
-        P = self.miner_weights(difficulty)
+        P = self.miner_selection_probabilities(difficulty)
 
         random_vals = np.random.rand(len(P))
         selected_mask = random_vals < P

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Four-stage autonomous mechanism for distributed problem solving
 Advanced AI algorithms curate complex graph problems from our distributed database. The system intelligently categorizes challenges by difficulty, graph structure, and computational requirements.
 
 ### Miner Selection
-Smart allocation engine matches problems to miners based on experience levels and historical performance. Stake-weighted distribution ensures optimal resource utilization across the network.
+Smart allocation engine filters eligible miners and samples each miner with the same difficulty-adjusted probability, keeping problem distribution fair while scaling participation by challenge difficulty.
 
 ### Scoring
 Dual-metric evaluation system assesses both solution optimality and algorithmic diversity. This approach rewards accuracy while encouraging innovative problem-solving methodologies.

--- a/common/base/__init__.py
+++ b/common/base/__init__.py
@@ -1,5 +1,5 @@
-base_version = "0.0.14"
-validator_version = "0.0.14"
+base_version = "0.0.15"
+validator_version = "0.0.15"
 
 
 def _version_to_int(version_str: str) -> int:

--- a/common/base/miner.py
+++ b/common/base/miner.py
@@ -26,6 +26,7 @@ class BaseMinerNeuron(BaseNeuron):
 
     def __init__(self, config=None):
         super().__init__(config=config)
+        axon_cls = getattr(bt, "axon", None) or getattr(bt, "Axon", None)
 
         # Warn if allowing incoming requests from anyone.
         if not self.config.blacklist.force_validator_permit:
@@ -37,7 +38,7 @@ class BaseMinerNeuron(BaseNeuron):
                 "You are allowing non-registered entities to send requests to your miner. This is a security risk."
             )
         # The axon handles request processing, allowing validators to send this miner requests.
-        self.axon = bt.axon(
+        self.axon = axon_cls(
             wallet=self.wallet,
             config=self.config() if callable(self.config) else self.config,
         )
@@ -175,10 +176,10 @@ class BaseMinerNeuron(BaseNeuron):
         # Sync the metagraph.
         self.metagraph.sync(subtensor=self.subtensor)
 
-    async def forward(self, synapse: bt.synapse) -> bt.synapse:
+    async def forward(self, synapse: bt.Synapse) -> bt.Synapse:
         return synapse
 
-    async def blacklist(self, synapse: bt.synapse) -> typing.Tuple[bool, str]:
+    async def blacklist(self, synapse: bt.Synapse) -> typing.Tuple[bool, str]:
         """
         Determines whether an incoming request should be blacklisted and thus ignored. Your implementation should
         define the logic for blacklisting requests based on your needs and desired security parameters.
@@ -188,7 +189,7 @@ class BaseMinerNeuron(BaseNeuron):
         requests before they are deserialized to avoid wasting resources on requests that will be ignored.
 
         Args:
-            synapse (bt.synapse): A synapse object constructed from the headers of the incoming request.
+            synapse: A synapse object constructed from the headers of the incoming request.
 
         Returns:
             Tuple[bool, str]: A tuple containing a boolean indicating whether the synapse's hotkey is blacklisted,
@@ -237,7 +238,7 @@ class BaseMinerNeuron(BaseNeuron):
         )
         return False, "Hotkey recognized!"
 
-    async def priority(self, synapse: bt.synapse) -> float:
+    async def priority(self, synapse: bt.Synapse) -> float:
         """
         The priority function determines the order in which requests are handled. More valuable or higher-priority
         requests are processed before others. You should design your own priority mechanism with care.
@@ -245,7 +246,7 @@ class BaseMinerNeuron(BaseNeuron):
         This implementation assigns priority to incoming requests based on the calling entity's stake in the metagraph.
 
         Args:
-            synapse (bt.synapse): The synapse object that contains metadata about the incoming request.
+            synapse: The synapse object that contains metadata about the incoming request.
 
         Returns:
             float: A priority score derived from the stake of the calling entity.

--- a/common/base/neuron.py
+++ b/common/base/neuron.py
@@ -1,10 +1,11 @@
 import copy
+import time
 from abc import ABC, abstractmethod
 
 import bittensor as bt
 from common.base import base_version
 from common.utils.config import add_args, check_config, config
-from common.utils.misc import ttl_get_block
+
 
 class BaseNeuron(ABC):
     """
@@ -34,7 +35,18 @@ class BaseNeuron(ABC):
 
     @property
     def block(self):
-        return ttl_get_block(self)
+        block_cache_ttl = self.config.neuron.block_cache_ttl
+        if block_cache_ttl <= 0:
+            return self.subtensor.get_current_block()
+
+        now = time.time()
+        if (
+            not hasattr(self, "_cached_block")
+            or now - self._cached_block_time >= block_cache_ttl
+        ):
+            self._cached_block = self.subtensor.get_current_block()
+            self._cached_block_time = now
+        return self._cached_block
 
     def __init__(self, config=None):
         base_config = copy.deepcopy(config or BaseNeuron.config())
@@ -152,6 +164,9 @@ class BaseNeuron(ABC):
 
         # Check if enough epoch blocks have elapsed since the last epoch.
         if (self.block - self.last_set_weight) < (self.config.neuron.epoch_length / 2):
+            bt.logging.debug(
+                f"Not setting weights because only {self.block - self.last_set_weight} blocks have elapsed since the last time weights were set, which is less than half of the configured epoch length of {self.config.neuron.epoch_length} blocks."
+            )
             return False
 
         # Ensure it's past the midpoint of the current epoch.
@@ -159,6 +174,9 @@ class BaseNeuron(ABC):
             netuid=self.config.netuid, block=self.block
         )
         if subnet_info.blocks_since_epoch * 2 < self.config.neuron.epoch_length:
+            bt.logging.debug(
+                f"Not setting weights because we are only {subnet_info.blocks_since_epoch} blocks into the current epoch, which is less than half of the configured epoch length of {self.config.neuron.epoch_length} blocks."
+            )
             return False
         return True
 

--- a/common/base/neuron.py
+++ b/common/base/neuron.py
@@ -6,7 +6,6 @@ from common.base import base_version
 from common.utils.config import add_args, check_config, config
 from common.utils.misc import ttl_get_block
 
-
 class BaseNeuron(ABC):
     """
     Base class for Bittensor miners. This class is abstract and should be inherited by a subclass. It contains the core logic for all neurons; validators and miners.
@@ -42,7 +41,9 @@ class BaseNeuron(ABC):
         self.config = self.config()
         self.config.merge(base_config)
         self.check_config(self.config)
-
+        wallet_cls = getattr(bt, "wallet", None) or getattr(bt, "Wallet", None)
+        subtensor_cls = getattr(bt, "subtensor", None) or getattr(bt, "Subtensor", None)
+        
         # Set up logging with the provided configuration.
         bt.logging.set_config(config=self.config.logging)
 
@@ -56,8 +57,8 @@ class BaseNeuron(ABC):
         # These are core Bittensor classes to interact with the network.
         bt.logging.info("Setting up bittensor objects.")
 
-        self.wallet = bt.wallet(config=self.config)
-        self.subtensor = bt.subtensor(
+        self.wallet = wallet_cls(config=self.config)
+        self.subtensor = subtensor_cls(
             network=self.config.subtensor.network, config=self.config
         )
         self.metagraph = self.subtensor.metagraph(self.config.netuid)
@@ -132,19 +133,21 @@ class BaseNeuron(ABC):
         return True
 
     def should_set_weights(self) -> bool:
-        # Don't set weights on initialization.
-        if self.step == 0:
-            return False
-
-        # Don't set weights until after 100 steps.
-        if (self.step - self.init_step) < 100:
-            return False
-
         if self.config.neuron.disable_set_weights:
             return False
 
         # Don't set weights if you're a miner.
         if self.neuron_type == "MinerNeuron":
+            return False
+
+        # Don't set weights on initialization.
+        if self.step == 0:
+            return False
+
+        # Don't set weights until enough startup steps have passed.
+        if (
+            self.step - self.init_step
+        ) < self.config.neuron.min_steps_before_set_weights:
             return False
 
         # Check if enough epoch blocks have elapsed since the last epoch.

--- a/common/base/validator.py
+++ b/common/base/validator.py
@@ -38,11 +38,13 @@ class BaseValidatorNeuron(BaseNeuron):
 
     def __init__(self, config=None):
         super().__init__(config=config)
+        dendrite_cls = getattr(bt, "dendrite", None) or getattr(bt, "Dendrite", None)
+        axon_cls = getattr(bt, "axon", None) or getattr(bt, "Axon", None)
 
         # Save a copy of the hotkeys to local memory.
         self.hotkeys = copy.deepcopy(self.metagraph.hotkeys)
 
-        self.dendrite = bt.dendrite(wallet=self.wallet)
+        self.dendrite = dendrite_cls(wallet=self.wallet)
         bt.logging.info(f"Dendrite: {self.dendrite}")
 
         # Set up initial scoring weights for validation
@@ -54,7 +56,7 @@ class BaseValidatorNeuron(BaseNeuron):
         bt.logging.info("load_state()")
         self.load_state()
 
-        self.axon = bt.axon(
+        self.axon = axon_cls(
             wallet=self.wallet,
             config=self.config() if callable(self.config) else self.config,
         )
@@ -77,8 +79,9 @@ class BaseValidatorNeuron(BaseNeuron):
         """Serve axon to enable external connections."""
 
         bt.logging.info("serving ip to chain...")
+        axon_cls = getattr(bt, "axon", None) or getattr(bt, "Axon", None)
         try:
-            self.axon = bt.axon(wallet=self.wallet, config=self.config)
+            self.axon = axon_cls(wallet=self.wallet, config=self.config)
 
             try:
                 bt.logging.info(

--- a/common/utils/config.py
+++ b/common/utils/config.py
@@ -71,6 +71,13 @@ def add_args(cls, parser):
     )
 
     parser.add_argument(
+        "--neuron.block_cache_ttl",
+        type=float,
+        help="Seconds to cache the current block. Set to 0 to disable block caching.",
+        default=12.0,
+    )
+
+    parser.add_argument(
         "--neuron.events_retention_size",
         type=str,
         help="Events retention size.",

--- a/common/utils/config.py
+++ b/common/utils/config.py
@@ -149,6 +149,13 @@ def add_validator_args(cls, parser):
     )
 
     parser.add_argument(
+        "--neuron.min_steps_before_set_weights",
+        type=int,
+        help="Minimum number of steps after startup before setting weights.",
+        default=100,
+    )
+
+    parser.add_argument(
         "--neuron.ema_alpha",
         type=float,
         help="Exponential moving average alpha parameter, how much to add of the new observation.",
@@ -182,9 +189,16 @@ def config(cls):
     Returns the configuration object specific to this miner or validator after adding relevant arguments.
     """
     parser = argparse.ArgumentParser()
-    bt.wallet.add_args(parser)
-    bt.subtensor.add_args(parser)
+    wallet_cls = getattr(bt, "wallet", None) or getattr(bt, "Wallet", None)
+    subtensor_cls = getattr(bt, "subtensor", None) or getattr(bt, "Subtensor", None)
+    axon_cls = getattr(bt, "axon", None) or getattr(bt, "Axon", None)
+
+    wallet_cls.add_args(parser)
+    subtensor_cls.add_args(parser)
     bt.logging.add_args(parser)
-    bt.axon.add_args(parser)
+    axon_cls.add_args(parser)
     cls.add_args(parser)
-    return bt.config(parser)
+    config_builder = getattr(bt, "config", None)
+    if config_builder is not None:
+        return config_builder(parser)
+    return bt.Config(parser)

--- a/docs/mechanism.md
+++ b/docs/mechanism.md
@@ -30,7 +30,7 @@ Problems are classified according to the following attributes:
 -   **Label**
     -   General: general graph without guaranteed features.
 -   **Limit**
-    -   Time: Time constraints. Currently, the time limit is sampled from ${10s, 15s, 30s}$.
+    -   Time: Time constraints. Currently, the time limit is sampled from ${6s, 7.5s, 10s, 15s, 30s}$.
 
 ## Difficulty Level
 
@@ -42,12 +42,11 @@ We continuously refine this formula based on miner performance and internal expe
 
 ### Latest
 
-Currently, we have only 4 types of problems:
+Currently, we have 3 types of problems:
 
--   Easy (difficulty=0.1): general graph with $90≤|V|≤100$
 -   Medium (difficulty=0.2): general graph with $290≤|V|≤300$
--   Hard (difficulty=0.3): general graph with $490≤|V|≤500$
--   Very Hard (difficulty=0.4): general graph with $690≤|V|≤700$
+-   Hard (difficulty=0.4): general graph with $490≤|V|≤500$
+-   Very Hard (difficulty=1): general graph with $690≤|V|≤700$
 
 ## Selection Process
 
@@ -64,52 +63,31 @@ The validator retrieves a random problem of type $t$ from our database. **Each p
 
 # Miner Selection
 
-To lower the entry barrier for new participants, we assign experienced miners problems with higher frequency and difficulty.
+To lower the entry barrier for new participants, we sample eligible miners with equal probability for each problem. The probability is adjusted by problem difficulty.
 
-New miners can focus on basic problems during their initial participation and gradually receive more diverse and difficult problems as they demonstrate their computational ability.
-
-Since miners with higher historical rewards naturally have higher stake, we use alpha stake as a proxy for miner experience.
+Before sampling, the validator filters out validator nodes and recently updated miners. The remaining miners are eligible to receive the problem.
 
 In brief, miner selection includes the following steps:
 
-1.  Calculate each miner's alpha stake.
-2.  Sample miners to distribute the problem accordingly.
-
-Let's examine each step in detail.
-
-## Stake Calculation
-
-Miners can earn more by staking their alphas on validators, while the official validator benefits from greater impact to stabilize scoring quality.
-
-Our win-win proposal: we include a miner's stake on our validator when calculating their total miner stake.
-
-Here's how we calculate a miner's alpha stake:
-
--   Suppose a miner registers with coldkey=`C` and hotkey=`H`.
--   The amount of alpha that `C` stakes on `H` is `S_miner`.
--   The amount of alpha that `C` stakes on our validator is `S_validator`.
--   The number of miners registered by `C` is `N_miner`.
-
-The miner's alpha stake would be `S_miner` + `S_validator` / `N_miner`. This means the credit for alphas staked on our validator by a coldkey is divided equally among all its miners.
+1.  Filter out validator nodes and miners updated within the current epoch.
+2.  Calculate a difficulty-adjusted selection probability.
+3.  Independently sample each eligible miner with that same probability.
 
 ## Miner Sampling
 
-The probability that a miner $m$ receives a problem $p$, denoted as $P(m, p)$, depends on the miner's experience level, $x(m)$, and the problem's difficulty level, $d(p)$.
+The probability that an eligible miner receives a problem $p$, denoted as $P(p)$, depends only on the problem's difficulty level, $d(p)$, and a fixed reference parameter, $r_{ref}$.
 
-We calculate $x(m)$ using the miner's alpha stake, $s_m$, and the average of all miners' alpha stakes, $\overline{S}$:
+We use:
 
-$$ x(m) = \sqrt{1 + \frac{s_m}{\overline{S}}} $$
+$$ r_{ref} = 1.5 $$
 
-The probability is then determined by:
+$$ x = \sqrt{1 + r_{ref}} $$
 
-$$ P(m, p) = 1 - e^{-max(0, x(m)-d(p)-0.5)} $$
+The selection probability is:
 
-With this formula, miners with more experience receive both a greater number and variety of problems.
+$$ P(p) = 1 - e^{-max(0, x-d(p)-0.5)} $$
 
--   Newbie miners (with zero stake) only receive problems where $d(p) < 0.5$.
--   Average miners (with stake roughly equal to the average) can receive most problems where $d(p) < 0.914$.
--   Experienced miners receive not only more difficult problems but also more problems overall.
--   If all miners have no stakes, then $x(m):=1 \forall m \in M$
+Every eligible miner receives the same probability $P(p)$ for a given problem. Harder problems produce lower selection probabilities, while easier problems are distributed to more miners on average.
 
 # Scoring
 

--- a/docs/wandb_logging.md
+++ b/docs/wandb_logging.md
@@ -19,7 +19,8 @@ The structured logging format is defined using a Pydantic model in [WandbRunLogD
 | Field               | Type              | Description                                                     |
 | ------------------- | ---------------- | ---------------------------------------------------------------- |
 | **label**           | str               | Problem category, e.g., general.                                |
-| **difficulty**      | float             | Problem difficulty in [0,1], derived from problem attributes.   |
+| **difficulty**      | float             | Difficulty assigned to the selected problem type.               |
+| **time_limit**      | float             | Time limit sent to miners, in seconds.                          |
 | **number_of_nodes** | int               | The number of vertices in the graph.                            |
 | **adjacency_list**  | list[list[int]]   | Adjacency list representation of the graph **after shuffling**. |
 | **encoded_matrix**  | str               | The base92 encoded adjacency matrix of the graph.               |

--- a/min_compute.yml
+++ b/min_compute.yml
@@ -7,7 +7,7 @@
 
 # NOTE: Specification for miners may be different from validators
 
-version: '0.0.14' # update this version key as needed, ideally should match your release version
+version: '0.0.15' # update this version key as needed, ideally should match your release version
 
 compute_spec:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,13 +2,13 @@ starlette>=0.30.0
 pydantic>=2
 rich>=13
 pytest>=8
-numpy>=2.2.6
+numpy==2.2.6
 setuptools>=68
 networkx==3.4.2
 pytest
 substrate-interface
-bittensor==9.10.0
-bittensor-cli>=9.13.0
+async-substrate-interface==1.6.4
+bittensor==10.2.1
 httpx
 scipy==1.15.3
 PyYAML==6.0.2

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,9 @@
 import codecs
 import os
-import pathlib
 import re
 from io import open
 from os import path
 
-from pkg_resources import parse_requirements
 from setuptools import find_packages, setup
 
 


### PR DESCRIPTION
# Improvements

- Updated miner selection to use equal difficulty-adjusted sampling probabilities.
- Added `neuron.block_cache_ttl` and `neuron.min_steps_before_set_weights` for configurable validator behavior.
- Added edge list conversion helpers to `GraphCodec`.
- Avoided importing the optional GNN clique algorithm by default.
- Updated mechanism and W&B logging documentation.

# Dependencies

- Migrated to Bittensor `v10.2.1`.
- Pinned `async-substrate-interface` to `1.6.4`.
- Pinned `numpy` to `2.2.6`.
