### PR TITLE
CliqueAI v0.0.16

### DIFF
--- a/CliqueAI/selection/problem_selector.py
+++ b/CliqueAI/selection/problem_selector.py
@@ -23,7 +23,7 @@ PROBLEMS = [
         label="general",
         vertex_range=Range(min=290, max=300),
         edge_range=Range(min=100, max=max_int),
-        difficulty=0.6,
+        difficulty=0.7,
     ),
     Problem(
         label="general",
@@ -35,15 +35,14 @@ PROBLEMS = [
         label="general",
         vertex_range=Range(min=690, max=700),
         edge_range=Range(min=0, max=max_int),
-        difficulty=1,
-        # difficulty=0.6,
+        difficulty=0.9,
     ),
-    # Problem(
-    #     label="general",
-    #     vertex_range=Range(min=890, max=900),
-    #     edge_range=Range(min=0, max=max_int),
-    #     difficulty=0.8,
-    # ),
+    Problem(
+        label="general",
+        vertex_range=Range(min=890, max=900),
+        edge_range=Range(min=0, max=max_int),
+        difficulty=1.0,
+    ),
 ]
 
 TIME_LIMITS = [6, 7.5, 10, 15, 30]

--- a/CliqueAI/selection/problem_selector.py
+++ b/CliqueAI/selection/problem_selector.py
@@ -23,13 +23,13 @@ PROBLEMS = [
         label="general",
         vertex_range=Range(min=290, max=300),
         edge_range=Range(min=100, max=max_int),
-        difficulty=0.2,
+        difficulty=0.6,
     ),
     Problem(
         label="general",
         vertex_range=Range(min=490, max=500),
         edge_range=Range(min=0, max=max_int),
-        difficulty=0.4,
+        difficulty=0.8,
     ),
     Problem(
         label="general",

--- a/CliqueAI/selection/problem_selector.py
+++ b/CliqueAI/selection/problem_selector.py
@@ -1,9 +1,10 @@
 import random
 
 from CliqueAI.selection.miner_selector import MinerSelector
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 max_int = 1e9
+DEFAULT_TIME_LIMITS = [6, 7.5, 10, 15, 30]
 
 
 class Range(BaseModel):
@@ -16,6 +17,7 @@ class Problem(BaseModel):
     vertex_range: Range
     edge_range: Range
     difficulty: float
+    time_limits: list[float] = Field(default_factory=lambda: DEFAULT_TIME_LIMITS.copy())
 
 
 PROBLEMS = [
@@ -42,10 +44,9 @@ PROBLEMS = [
         vertex_range=Range(min=890, max=900),
         edge_range=Range(min=0, max=max_int),
         difficulty=1.0,
+        time_limits=[7.5, 10, 15, 30],
     ),
 ]
-
-TIME_LIMITS = [6, 7.5, 10, 15, 30]
 
 
 class ProblemSelector:
@@ -56,6 +57,7 @@ class ProblemSelector:
         selected_problem = random.choice(PROBLEMS)
         return selected_problem
 
-    def select_time_limit(self):
-        selected_time_limit = random.choice(TIME_LIMITS)
+    def select_time_limit(self, problem: Problem | None = None):
+        time_limits = problem.time_limits if problem is not None else DEFAULT_TIME_LIMITS
+        selected_time_limit = random.choice(time_limits)
         return selected_time_limit

--- a/CliqueAI/validator.py
+++ b/CliqueAI/validator.py
@@ -95,7 +95,7 @@ class Validator(BaseValidatorNeuron):
 
         # Problem Selection
         problem = problem_selector.select_problem()
-        time_limit = problem_selector.select_time_limit()
+        time_limit = problem_selector.select_time_limit(problem)
         try:
             graph = await get_graph(
                 wallet=self.wallet,

--- a/common/base/__init__.py
+++ b/common/base/__init__.py
@@ -1,5 +1,5 @@
-base_version = "0.0.15"
-validator_version = "0.0.15"
+base_version = "0.0.16"
+validator_version = "0.0.16"
 
 
 def _version_to_int(version_str: str) -> int:

--- a/common/base/utils/signature.py
+++ b/common/base/utils/signature.py
@@ -1,12 +1,31 @@
 import bittensor as bt
 
 
-def verify_signature(signature: str, timestamp: int, hotkey: str) -> bool:
-    message = f"{timestamp}:{hotkey}"
+def _timestamp_text(timestamp: int | float) -> str:
+    if isinstance(timestamp, float) and timestamp.is_integer():
+        return str(int(timestamp))
+    return str(timestamp)
+
+
+def _signature_message(timestamp: int | float, hotkey: str) -> str:
+    return f"{_timestamp_text(timestamp)}:{hotkey}"
+
+
+def verify_signature(signature: str, timestamp: int | float, hotkey: str) -> bool:
+    message = _signature_message(timestamp, hotkey)
     keypair = bt.Keypair(ss58_address=hotkey)
-    return keypair.verify(signature=signature, message=message)
+    try:
+        return bool(keypair.verify(signature=signature, message=message))
+    except TypeError:
+        try:
+            return bool(keypair.verify(message, bytes.fromhex(signature)))
+        except Exception:
+            return False
+    except Exception:
+        return False
 
 
 def create_signature(wallet: bt.Wallet, timestamp: int) -> str:
-    message = f"{timestamp}:{wallet.hotkey}"
-    return wallet.hotkey.sign(message)
+    hotkey = wallet.hotkey.ss58_address
+    signature = wallet.hotkey.sign(_signature_message(timestamp, hotkey))
+    return signature.hex() if isinstance(signature, bytes) else str(signature)

--- a/common/base/utils/state_storage.py
+++ b/common/base/utils/state_storage.py
@@ -104,15 +104,20 @@ def load_latest_validator_state(path: str) -> Tuple[int, np.ndarray, list[str]]:
         raise ValueError("No validator state found in the database.")
 
 
-def get_all_validator_state(path: str) -> list[Tuple[int, list[float], list[str]]]:
+def get_all_validator_state(
+    path: str,
+    num: int | None = None,
+) -> list[Tuple[int, list[float], list[str], list[int]]]:
     """
     Get all validator states from the database.
 
     Args:
         path (str): The path to the directory containing the database.
+        num (int | None): Optional number of latest states to return.
 
     Returns:
-        list[Tuple[int, list[float], list[str]]]: A list of tuples containing step, scores, and hotkeys.
+        list[Tuple[int, list[float], list[str], list[int]]]: A list of tuples
+        containing step, scores, hotkeys, and EMA step counts.
     """
     db_path = os.path.join(path, "validator_state.db")
     if not os.path.exists(db_path):
@@ -120,8 +125,21 @@ def get_all_validator_state(path: str) -> list[Tuple[int, list[float], list[str]
 
     conn = sqlite3.connect(db_path)
     cursor = conn.cursor()
-    cursor.execute("SELECT step, scores, hotkeys FROM validator_state")
+    if num is None:
+        cursor.execute(
+            "SELECT step, scores, hotkeys, ema_step_count "
+            "FROM validator_state ORDER BY step DESC"
+        )
+    else:
+        cursor.execute(
+            "SELECT step, scores, hotkeys, ema_step_count "
+            "FROM validator_state ORDER BY step DESC LIMIT ?",
+            (num,),
+        )
     rows = cursor.fetchall()
     conn.close()
 
-    return [(row[0], json.loads(row[1]), json.loads(row[2])) for row in rows]
+    return [
+        (row[0], json.loads(row[1]), json.loads(row[2]), json.loads(row[3]))
+        for row in rows
+    ]

--- a/common/base/validator.py
+++ b/common/base/validator.py
@@ -8,7 +8,6 @@ from typing import List, Union
 
 import bittensor as bt
 import numpy as np
-from scipy.stats import rankdata
 from common.base import validator_int_version
 from common.base.middleware.bypass_axon_middleware import replace_axon_middleware
 from common.base.neuron import BaseNeuron
@@ -30,6 +29,8 @@ class BaseValidatorNeuron(BaseNeuron):
     """
 
     neuron_type: str = "ValidatorNeuron"
+    POWER_TARGET_TOP_HALF_SHARE: float = 0.80
+    POWER_MAX_GAMMA: float = 32.0
 
     @classmethod
     def add_args(cls, parser: argparse.ArgumentParser):
@@ -249,16 +250,51 @@ class BaseValidatorNeuron(BaseNeuron):
 
     def _sigmoid_weight(self, normalized_incentives: np.ndarray, midpoint: float, steepness: float) -> np.ndarray:
         """
-        Apply sigmoid scaling to normalized incentives and down-weight by rank.
+        Apply sigmoid scaling to normalized incentives.
         """
         x = (normalized_incentives - midpoint) / steepness
-        sigmoid_incentives = 1 / (1 + np.exp(-x))
-        num_miners = len(sigmoid_incentives)
-        if num_miners > 0:
-            ranks = rankdata(-sigmoid_incentives, method="max").astype(np.float32)
-            rank_multipliers = (num_miners - ranks + 1) / num_miners
-            sigmoid_incentives = sigmoid_incentives * rank_multipliers
-        return sigmoid_incentives
+        return 1 / (1 + np.exp(-x))
+
+    def _top_half_share(self, weights: np.ndarray, rank_scores: np.ndarray) -> float:
+        total = np.sum(weights)
+        if total <= 0:
+            return 0.0
+        order = np.argsort(-rank_scores)
+        top = order[: len(order) // 2]
+        return float(np.sum(weights[top]) / total)
+
+    def _power_weight(
+        self,
+        sigmoid_incentives: np.ndarray,
+        rank_scores: np.ndarray,
+        target_top_half_share: float,
+    ) -> tuple[np.ndarray, float]:
+        active = sigmoid_incentives > 0
+        if not np.any(active):
+            return np.zeros_like(sigmoid_incentives, dtype=np.float64), 0.0
+
+        def transform(gamma: float) -> np.ndarray:
+            weights = np.zeros_like(sigmoid_incentives, dtype=np.float64)
+            weights[active] = np.power(sigmoid_incentives[active], gamma)
+            return weights
+
+        lo = 0.0
+        max_gamma = self.POWER_MAX_GAMMA
+        hi = min(1.0, max_gamma)
+        while (
+            self._top_half_share(transform(hi), rank_scores) < target_top_half_share
+            and hi < max_gamma
+        ):
+            hi = min(hi * 2.0, max_gamma)
+
+        for _ in range(80):
+            mid = (lo + hi) / 2.0
+            if self._top_half_share(transform(mid), rank_scores) < target_top_half_share:
+                lo = mid
+            else:
+                hi = mid
+
+        return transform(hi), hi
 
     def set_weights(self):
         """
@@ -284,14 +320,22 @@ class BaseValidatorNeuron(BaseNeuron):
         else:
             normalized = (self.scores - min_val) / range_val
 
-        # Apply sigmoid scaling to the normalized scores to determine the weights.
+        # Apply sigmoid scaling with power scaling.
         zero_mask = (normalized == 0)
         nonzero_normalized = normalized[~zero_mask]
         if nonzero_normalized.size > 0:
             midpoint = np.median(nonzero_normalized)
             steepness = max(np.percentile(nonzero_normalized, 75) - np.percentile(nonzero_normalized, 25), 0.1)  # IQR
-            sigmoid_weights = self._sigmoid_weight(normalized, midpoint=midpoint, steepness=steepness)
-            sigmoid_weights[zero_mask] = 0.0
+            sigmoid_scores = self._sigmoid_weight(normalized, midpoint=midpoint, steepness=steepness)
+            sigmoid_scores[zero_mask] = 0.0
+            sigmoid_weights, power_gamma = self._power_weight(
+                sigmoid_scores,
+                normalized,
+                self.POWER_TARGET_TOP_HALF_SHARE,
+            )
+            bt.logging.debug(
+                f"Power weight gamma={power_gamma:.9f}, target_top_half_share={self.POWER_TARGET_TOP_HALF_SHARE:.3f}"
+            )
         else:
             sigmoid_weights = normalized
 

--- a/common/base/validator.py
+++ b/common/base/validator.py
@@ -483,21 +483,74 @@ class BaseValidatorNeuron(BaseNeuron):
                 "No previous validator state found. Starting from scratch."
             )
 
+    def _get_owner_hotkey(self) -> str:
+        if hasattr(self.subtensor, "get_subnet_owner_hotkey"):
+            try:
+                owner_hotkey = self.subtensor.get_subnet_owner_hotkey(
+                    netuid=self.config.netuid,
+                    block=self.block,
+                )
+                if owner_hotkey:
+                    return owner_hotkey
+            except TypeError:
+                try:
+                    owner_hotkey = self.subtensor.get_subnet_owner_hotkey(
+                        netuid=self.config.netuid
+                    )
+                    if owner_hotkey:
+                        return owner_hotkey
+                except Exception:
+                    pass
+            except Exception:
+                pass
+
+        owner_hotkey = getattr(self.metagraph, "owner_hotkey", None)
+        if owner_hotkey:
+            return owner_hotkey
+
+        hotkeys = getattr(self.metagraph, "hotkeys", [])
+        if hotkeys:
+            return hotkeys[0]
+
+        raise ValueError("Unable to determine subnet owner hotkey.")
+
     async def get_validator_state(
         self,
         timestamp: float,
         owner_signature: str,
-    ) -> list[dict]:
+        num: int | None = None,
+    ) -> list[tuple[int, list[float], list[str], list[int]]]:
         bt.logging.info("Received request for validator state.")
         now = time.time()
         if abs(now - timestamp) > 60:
             bt.logging.warning("Request expired.")
             raise HTTPException(status_code=400, detail="Request expired.")
+        if num is not None and num <= 0:
+            raise HTTPException(status_code=400, detail="num must be greater than 0.")
 
-        if not verify_signature(
-            owner_signature, timestamp, self.metagraph.owner_hotkey
-        ):
+        try:
+            owner_hotkey = self._get_owner_hotkey()
+        except Exception as exc:
+            detail = (
+                "Failed to determine subnet owner hotkey: "
+                f"{type(exc).__name__}: {exc}"
+            )
+            bt.logging.error(detail)
+            raise HTTPException(status_code=500, detail=detail) from exc
+
+        if not verify_signature(owner_signature, timestamp, owner_hotkey):
             bt.logging.warning("Invalid owner signature.")
             raise HTTPException(status_code=403, detail="Invalid owner signature.")
 
-        return get_all_validator_state(path=self.config.neuron.full_path)
+        try:
+            return get_all_validator_state(
+                path=self.config.neuron.full_path,
+                num=num,
+            )
+        except Exception as exc:
+            detail = (
+                "Failed to load validator state: "
+                f"{type(exc).__name__}: {exc}"
+            )
+            bt.logging.error(detail)
+            raise HTTPException(status_code=500, detail=detail) from exc

--- a/min_compute.yml
+++ b/min_compute.yml
@@ -7,7 +7,7 @@
 
 # NOTE: Specification for miners may be different from validators
 
-version: '0.0.15' # update this version key as needed, ideally should match your release version
+version: '0.0.16' # update this version key as needed, ideally should match your release version
 
 compute_spec:
 


### PR DESCRIPTION
# Improvements

- Increased general problem difficulty for `290–300` and `490–500` vertex graphs.
- Replaced rank-based sigmoid weighting with power scaling for validator weights.
- Improved validator state retrieval with optional latest-state limits, `ema_step_count`, timestamp normalization, and Bittensor v10 `Keypair.verify` compatibility.
- Added `890-900` vertex graphs.
- Removed the `6s` time limit for `890-900` vertex graphs.